### PR TITLE
fix: Add drop task initial connect retry

### DIFF
--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -850,17 +850,13 @@ async fn drop_task(
 ) -> Result<()> {
     const MAX_RETRIES: usize = 1;
     const RETRY_DELAY: Duration = Duration::from_secs(1);
-    // Recovery tests intentionally crash the server (crash_on_packet), and the
+    // Recovery tests intentionally crash the server, and the
     // dropper's startup connect runs concurrently with the test -- it can be in
     // flight when that crash kills the server, surfacing as a one-off
-    // "connection closed". That's the only un-retried step on this task, so
-    // without a retry it fails the whole run even though the DROP below already
-    // retries.
-    //
+    // "connection closed". 
     // CONNECT_RETRIES is deliberately much larger than MAX_RETRIES because the
     // two cover different situations. The DROP runs *after* the test, when the
-    // server is already back up -- its only failure mode is a stale connection,
-    // so a single reconnect to the live server suffices (MAX_RETRIES = 1). This
+    // server is already back up. This
     // connect can instead land *during* the crash/restart window, when the
     // server is genuinely down, so it must keep trying long enough to outlast a
     // full restart -- many more attempts than reconnecting to an already-up

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -850,12 +850,21 @@ async fn drop_task(
 ) -> Result<()> {
     const MAX_RETRIES: usize = 1;
     const RETRY_DELAY: Duration = Duration::from_secs(1);
-    // Recovery tests intentionally crash the server (crash_on_packet). The
-    // dropper's startup connect runs concurrently with the test and can be in
+    // Recovery tests intentionally crash the server (crash_on_packet), and the
+    // dropper's startup connect runs concurrently with the test -- it can be in
     // flight when that crash kills the server, surfacing as a one-off
-    // "connection closed" -- the one un-retried step on this task, so it would
-    // fail the whole run even though the DROP below is already retried. Retry
-    // the connect across the crash/restart window instead of propagating.
+    // "connection closed". That's the only un-retried step on this task, so
+    // without a retry it fails the whole run even though the DROP below already
+    // retries.
+    //
+    // CONNECT_RETRIES is deliberately much larger than MAX_RETRIES because the
+    // two cover different situations. The DROP runs *after* the test, when the
+    // server is already back up -- its only failure mode is a stale connection,
+    // so a single reconnect to the live server suffices (MAX_RETRIES = 1). This
+    // connect can instead land *during* the crash/restart window, when the
+    // server is genuinely down, so it must keep trying long enough to outlast a
+    // full restart -- many more attempts than reconnecting to an already-up
+    // server.
     const CONNECT_RETRIES: usize = 10;
     let mut connect_attempts = 0;
     let mut db = loop {

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -853,7 +853,7 @@ async fn drop_task(
     // Recovery tests intentionally crash the server, and the
     // dropper's startup connect runs concurrently with the test -- it can be in
     // flight when that crash kills the server, surfacing as a one-off
-    // "connection closed". 
+    // "connection closed".
     // CONNECT_RETRIES is deliberately much larger than MAX_RETRIES because the
     // two cover different situations. The DROP runs *after* the test, when the
     // server is already back up. This

--- a/sqllogictest-bin/src/main.rs
+++ b/sqllogictest-bin/src/main.rs
@@ -850,7 +850,26 @@ async fn drop_task(
 ) -> Result<()> {
     const MAX_RETRIES: usize = 1;
     const RETRY_DELAY: Duration = Duration::from_secs(1);
-    let mut db = engines::connect(&engine, &config, SslMode::Disable, DBPort::Plain).await?;
+    // Recovery tests intentionally crash the server (crash_on_packet). The
+    // dropper's startup connect runs concurrently with the test and can be in
+    // flight when that crash kills the server, surfacing as a one-off
+    // "connection closed" -- the one un-retried step on this task, so it would
+    // fail the whole run even though the DROP below is already retried. Retry
+    // the connect across the crash/restart window instead of propagating.
+    const CONNECT_RETRIES: usize = 10;
+    let mut connect_attempts = 0;
+    let mut db = loop {
+        match engines::connect(&engine, &config, SslMode::Disable, DBPort::Plain).await {
+            Ok(conn) => break conn,
+            Err(e) => {
+                connect_attempts += 1;
+                if connect_attempts > CONNECT_RETRIES {
+                    return Err(e.into());
+                }
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+        }
+    };
 
     while let Some(message) = drop_rx.recv().await {
         match message {

--- a/sqllogictest-engines/src/postgres/extended.rs
+++ b/sqllogictest-engines/src/postgres/extended.rs
@@ -244,7 +244,9 @@ impl<'a> FromSql<'a> for TimestampValue {
                 return Ok(TimestampValue("-infinity".into()));
             }
         }
-        Ok(TimestampValue(NaiveDateTime::from_sql(ty, raw)?.to_string()))
+        Ok(TimestampValue(
+            NaiveDateTime::from_sql(ty, raw)?.to_string(),
+        ))
     }
 
     accepts!(TIMESTAMP);

--- a/sqllogictest/src/substitution.rs
+++ b/sqllogictest/src/substitution.rs
@@ -44,9 +44,7 @@ fn escape_bare_dollars(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut chars = input.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == '$'
-            && !matches!(chars.peek(), Some(&('{' | 'a'..='z' | 'A'..='Z' | '_')))
-        {
+        if c == '$' && !matches!(chars.peek(), Some(&('{' | 'a'..='z' | 'A'..='Z' | '_'))) {
             out.push('\\');
         }
         out.push(c);


### PR DESCRIPTION
Drop task can "see" server in crashed state in recovery tests during initial connect. 
This PR add retries so drop task will wait until server comes up in unlucky case.